### PR TITLE
Fix: Wikimedia icon for Apex theme

### DIFF
--- a/src/themes/apex/icons-wikimedia.json
+++ b/src/themes/apex/icons-wikimedia.json
@@ -9,7 +9,7 @@
 			"file": "../wikimediaui/images/icons/logo-Wikidata.svg"
 		},
 		"logoWikimedia": {
-			"file": "../wikimediaui/images/icons/logo-Wikidata.svg"
+			"file": "../wikimediaui/images/icons/logo-Wikimedia.svg"
 		},
 		"logoWikimediaCommons": {
 			"file": "../wikimediaui/images/icons/logo-Wikimedia-Commons.svg"


### PR DESCRIPTION
Update copy / paste typo for the Wikimedia icon in the Apex theme from
Wikidata to Wikimedia.